### PR TITLE
[aml/meson6] Increase maximum audio output sampling rate to 192kHz

### DIFF
--- a/sound/soc/aml/m6/aml_dai.c
+++ b/sound/soc/aml/m6/aml_dai.c
@@ -184,7 +184,7 @@ static int aml_dai_pcm_resume(struct snd_soc_dai *dai)
 
 #endif
 
-#define AML_DAI_I2S_RATES		(SNDRV_PCM_RATE_8000_96000)
+#define AML_DAI_I2S_RATES		(SNDRV_PCM_RATE_8000_192000)
 #define AML_DAI_I2S_FORMATS		(SNDRV_PCM_FMTBIT_S16_LE | SNDRV_PCM_FMTBIT_S24_LE | SNDRV_PCM_FMTBIT_S32_LE)
 
 #ifdef AML_DAI_PCM_SUPPORT


### PR DESCRIPTION
This commit allows to output 192kHz streams over HDMI. Tested on WeTek Play with 2-channel 24-bit 192kHz FLAC and asound.conf modified to allow 24-bit output.

It might also help in fixing HD Audio output as it needs the 192kHz to work properly (can't test that).
